### PR TITLE
Merge develop into master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ isort==4.3.21
 joblib==0.14.1
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
-numpy==1.18.2
+numpy==1.22.0
 pylint==2.4.4
 requests==2.23.0
 scikit-learn==0.22.2.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ scipy==1.4.1
 six==1.14.0
 sklearn==0.0
 soupsieve==2.0
-urllib3==1.25.9
+urllib3==1.26.5
 wrapt==1.11.2


### PR DESCRIPTION
## Summary
- promote the latest changes from develop to master
- bring the updated Python dependencies from PR #16 into the deployment branch
- allow the Python 3.13 CI/CD workflow to install dependencies and proceed to AWS deployment

## Context
The first post-merge deployment run failed because master still pins NumPy 1.18.2 and other dependencies that do not support Python 3.13. The dependency updates are already present on develop.